### PR TITLE
Fix scaling of time values in multi-line format (#17)

### DIFF
--- a/bin/user/influx.py
+++ b/bin/user/influx.py
@@ -434,7 +434,7 @@ class InfluxThread(weewx.restx.RESTThread):
                 if self.line_format == 'multi-line':
                     # use multiple lines
                     data.append('%s%s value=%s %d' %
-                                (name, tags, s, record['dateTime']*1000000))
+                                (name, tags, s, record['dateTime']*1000000000))
                 else:
                     # use a single line
                     data.append('%s=%s' % (name, s))


### PR DESCRIPTION
Fixes #17, tested with InfluxDB v1.0