### PR TITLE
Use .encode() to send request as bytes

### DIFF
--- a/bin/user/influx.py
+++ b/bin/user/influx.py
@@ -492,7 +492,7 @@ class InfluxThread(weewx.restx.RESTThread):
         # FIXME: provide full set of ssl options instead of this hack
         if self.server_url.startswith('https'):
             import ssl
-            return urlopen(request, data=payload, timeout=self.timeout,
+            return urlopen(request, data=payload.encode('utf-8'), timeout=self.timeout,
                            context=ssl._create_unverified_context())
         else:
             return super(InfluxThread, self).post_request(request, payload)


### PR DESCRIPTION
Use .encode() to make sure to send the request as bytes and not string.

Im using weewx 4.4 and python3 and was facing this error.

```
Mar 15 18:03:06 weather weewx[15631] INFO __main__: Initializing weewx version 4.4.0
Mar 15 18:03:06 weather weewx[15631] INFO __main__: Using Python 3.7.3 (default, Jul 25 2020, 13:03:44) #012[GCC 8.3.0]
Mar 15 18:03:06 weather weewx[15631] INFO __main__: Platform Linux-5.10.17-v7+-armv7l-with-debian-10.8
Mar 15 18:03:06 weather weewx[15631] INFO __main__: Locale is 'de_DE.UTF-8'
Mar 15 18:03:06 weather weewx[15631] INFO __main__: PID file is /var/run/weewx.pid
Mar 15 18:03:06 weather weewx[15635] INFO __main__: Using configuration file /etc/weewx/weewx.conf
Mar 15 18:03:06 weather weewx[15635] INFO __main__: Debug is 0
Mar 15 18:03:06 weather weewx[15635] INFO weewx.engine: Loading station type FineOffsetUSB (weewx.drivers.fousb)
Mar 15 18:03:06 weather weewx[15619]: Starting weewx weather system: weewx.
Mar 15 18:03:06 weather weewx[15635] INFO weewx.drivers.fousb: driver version is 1.20
Mar 15 18:03:06 weather weewx[15635] INFO weewx.drivers.fousb: polling mode is PERIODIC
Mar 15 18:03:06 weather weewx[15635] INFO weewx.drivers.fousb: polling interval is 60
Mar 15 18:03:06 weather weewx[15635] INFO weewx.drivers.fousb: found station on USB bus= device=
Mar 15 18:03:06 weather weewx[15635] INFO weewx.engine: StdConvert target unit is 0x1
Mar 15 18:03:06 weather weewx[15635] INFO weewx.engine: Archive will use data binding wx_binding
Mar 15 18:03:06 weather weewx[15635] INFO weewx.engine: Record generation will be attempted in 'hardware'
Mar 15 18:03:07 weather weewx[15635] INFO weewx.engine: Using archive interval of 1800 seconds (specified by hardware)
Mar 15 18:03:07 weather weewx[15635] INFO user.influx: service version is 0.15
Mar 15 18:03:07 weather weewx[15635] INFO user.influx: database is weewx
Mar 15 18:03:07 weather weewx[15635] INFO user.influx: desired unit system is METRICWX
Mar 15 18:03:07 weather weewx[15635] INFO user.influx: tags None
Mar 15 18:03:07 weather weewx[15635] INFO user.influx: binding is archive
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__: Caught unrecoverable exception:
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****  POST data should be bytes, an iterable of bytes, or a file object. It cannot be of type str.
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****  Traceback (most recent call last):
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****    File "/usr/share/weewx/weewxd", line 151, in main
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****      engine = weewx.engine.StdEngine(config_dict)
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****    File "/usr/share/weewx/weewx/engine.py", line 93, in __init__
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****      self.loadServices(config_dict)
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****    File "/usr/share/weewx/weewx/engine.py", line 161, in loadServices
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****      obj = weeutil.weeutil.get_object(svc)(self, config_dict)
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****    File "/usr/share/weewx/user/influx.py", line 349, in __init__
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****      data_thread = InfluxThread(data_queue, **site_dict)
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****    File "/usr/share/weewx/user/influx.py", line 427, in __init__
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****      self.create_database(uname, pword)
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****    File "/usr/share/weewx/user/influx.py", line 443, in create_database
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****      self.post_request(req, 'None')
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****    File "/usr/share/weewx/user/influx.py", line 496, in post_request
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****      context=ssl._create_unverified_context())
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****    File "/usr/lib/python3.7/urllib/request.py", line 222, in urlopen
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****      return opener.open(url, data, timeout)
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****    File "/usr/lib/python3.7/urllib/request.py", line 523, in open
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****      req = meth(req)
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****    File "/usr/lib/python3.7/urllib/request.py", line 1254, in do_request_
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****      raise TypeError(msg)
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****  TypeError: POST data should be bytes, an iterable of bytes, or a file object. It cannot be of type str.
Mar 15 18:03:07 weather weewx[15635] CRITICAL __main__:     ****  Exiting.
```